### PR TITLE
feat: replace docs index

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,165 +1,340 @@
-// Calculator logic
-const amountInput = document.getElementById('invoiceAmount');
-const rateInput = document.getElementById('rate');
-const rateValue = document.getElementById('rateValue');
-const presetButtons = document.querySelectorAll('.preset-amounts button');
-const termButtons = document.querySelectorAll('.term-buttons button');
-const sumAmount = document.getElementById('sumAmount');
-const sumFinanced = document.getElementById('sumFinanced');
-const sumDiscount = document.getElementById('sumDiscount');
-const sumFee = document.getElementById('sumFee');
-const sumNet = document.getElementById('sumNet');
-const navbar = document.querySelector('.navbar');
+// ==== Utilidades ====
+const formatCurrency = (amount) =>
+  new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP', maximumFractionDigits: 0 }).format(amount);
 
-let days = 30;
+const formatNumber = (v) => v.toString().replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+const parseNumber = (v) => parseInt(String(v).replace(/\./g, ''), 10) || 0;
 
-const fee = 50000;
-
-const format = (n) =>
-  n.toLocaleString('es-CL', { style: 'currency', currency: 'CLP', maximumFractionDigits: 0 });
-
-const formatNumber = (v) => v.replace(/\B(?=(\d{3})+(?!\d))/g, '.');
-const parseNumber = (v) => parseInt(v.replace(/\./g, ''), 10) || 0;
-
-function calculate() {
-  const amount = parseNumber(amountInput.value);
-  const rate = parseFloat(rateInput.value) || 0;
-  const discount = amount * (rate / 100) * (days / 30);
-  const net = amount - discount - fee;
-  sumAmount.textContent = format(amount);
-  sumFinanced.textContent = format(amount);
-  sumDiscount.textContent = format(discount);
-  sumFee.textContent = format(fee);
-  sumNet.textContent = format(net);
-  rateValue.textContent = `${rate.toFixed(1)}%`;
-}
-
-presetButtons.forEach((btn) =>
-  btn.addEventListener('click', () => {
-    amountInput.value = formatNumber(btn.dataset.value);
-    calculate();
-  })
-);
-
-termButtons.forEach((btn) =>
-  btn.addEventListener('click', () => {
-    termButtons.forEach((b) => b.classList.remove('active'));
-    btn.classList.add('active');
-    days = parseInt(btn.dataset.days, 10);
-    calculate();
-  })
-);
-
-amountInput.addEventListener('input', (e) => {
-  const raw = e.target.value.replace(/\D/g, '');
-  e.target.value = raw ? formatNumber(raw) : '';
-  calculate();
-});
-rateInput.addEventListener('input', () => {
-  rateValue.textContent = `${parseFloat(rateInput.value).toFixed(1)}%`;
-  calculate();
-});
-
-calculate();
-
-// Dynamic navbar
-if (navbar) {
-  let lastScroll = 0;
-  window.addEventListener('scroll', () => {
-    const current = window.pageYOffset;
-    if (current > lastScroll && current > 50) {
-      navbar.classList.add('nav-hidden');
-    } else {
-      navbar.classList.remove('nav-hidden');
-    }
-    if (current > 50) {
-      navbar.classList.add('scrolled');
-    } else {
-      navbar.classList.remove('scrolled');
-    }
-    lastScroll = current;
-  });
-}
-
-// Contact form
-const contactForm = document.getElementById('contactForm');
-if (contactForm) {
-  contactForm.addEventListener('submit', function (e) {
-    e.preventDefault();
-    alert('Gracias por tu mensaje. Nos pondremos en contacto pronto.');
-    this.reset();
-  });
-}
-
-
-// Login modal
-const loginToggle = document.getElementById('loginToggle');
-const loginModal = document.getElementById('loginModal');
-const loginClose = document.getElementById('loginClose');
-
-loginToggle.addEventListener('click', () => {
-  loginModal.classList.remove('hidden');
-  loginModal.removeAttribute('hidden');
-});
-
-loginClose.addEventListener('click', () => {
-  loginModal.classList.add('hidden');
-  loginModal.setAttribute('hidden', '');
-});
-
-loginModal.addEventListener('click', (e) => {
-  if (e.target === loginModal) {
-    loginModal.classList.add('hidden');
-    loginModal.setAttribute('hidden', '');
+// Valida RUT con Módulo 11 (DV 0/K)
+function validaRUT(rutStr){
+  const clean = String(rutStr).replace(/[^0-9kK]/g,'').toUpperCase();
+  if(clean.length < 2) return false;
+  const body = clean.slice(0,-1), dv = clean.slice(-1);
+  let sum=0, mul=2;
+  for(let i=body.length-1;i>=0;i--){
+    sum += parseInt(body[i],10)*mul;
+    mul = (mul===7)?2:mul+1;
   }
-
-});
-
-document.getElementById('loginForm').addEventListener('submit', function (e) {
-  e.preventDefault();
-  alert('Acceso de clientes próximamente disponible.');
-  this.reset();
-  loginModal.classList.add('hidden');
-  loginModal.setAttribute('hidden', '');
-});
-
-document.getElementById('btnFirmaDocsTop').addEventListener('click', () => {
-
-  alert('Firma de documentos próximamente disponible.');
-});
-
-const loginUser = document.getElementById('loginUser');
-loginUser.addEventListener('input', (e) => {
-  let v = e.target.value.replace(/[^0-9kK]/g, '').toUpperCase();
-  if (v.length > 1) {
-    const body = v.slice(0, -1).replace(/\B(?=(\d{3})+(?!\d))/g, '.');
-    const dv = v.slice(-1);
-    v = `${body}-${dv}`;
-  }
-  e.target.value = v;
-});
-
-
-// Gallery slideshow
-const gallerySlides = document.querySelectorAll('.gallery img');
-let currentSlide = 0;
-if (gallerySlides.length > 0) {
-  setInterval(() => {
-    gallerySlides[currentSlide].classList.remove('active');
-    currentSlide = (currentSlide + 1) % gallerySlides.length;
-    gallerySlides[currentSlide].classList.add('active');
-  }, 5000);
+  const res = 11 - (sum % 11);
+  const dvCalc = res===11?'0':res===10?'K':String(res);
+  return dv===dvCalc;
 }
 
-// Reveal on scroll
-const revealEls = document.querySelectorAll('.reveal');
-const observer = new IntersectionObserver((entries) => {
-  entries.forEach((entry) => {
-    if (entry.isIntersecting) {
-      entry.target.classList.add('visible');
-      observer.unobserve(entry.target);
-    }
-  });
-}, { threshold: 0.1 });
+const formatRUT = (rut) => {
+  const cleaned = rut.replace(/[^0-9kK]/g, '').toUpperCase();
+  if (cleaned.length <= 1) return cleaned;
+  const body = cleaned.slice(0, -1);
+  const dv = cleaned.slice(-1);
+  const formattedBody = body.replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+  return `${formattedBody}-${dv}`;
+};
 
-revealEls.forEach((el) => observer.observe(el));
+// ==== Calculadora ====
+class Calculator {
+  constructor() {
+    this.elements = {
+      amountInput: document.getElementById('invoiceAmount'),
+      rateSlider: document.getElementById('rate'),
+      rateDisplay: document.getElementById('rateDisplay'),
+      presetBtns: document.querySelectorAll('.preset-btn'),
+      termBtns: document.querySelectorAll('.term-btn'),
+      sumAmount: document.getElementById('sumAmount'),
+      sumFinanced: document.getElementById('sumFinanced'),
+      sumDiscount: document.getElementById('sumDiscount'),
+      sumFee: document.getElementById('sumFee'),
+      sumNet: document.getElementById('sumNet')
+    };
+    this.state = { days: 30, fee: 50000 };
+    this.init();
+  }
+  init() { this.bindEvents(); this.updateRateDisplay(); this.calculate(); }
+  bindEvents() {
+    this.elements.amountInput.addEventListener('input', (e) => {
+      const raw = e.target.value.replace(/\D/g, '');
+      e.target.value = raw ? formatNumber(raw) : '';
+      this.calculate();
+    });
+    this.elements.rateSlider.addEventListener('input', () => { this.updateRateDisplay(); this.calculate(); });
+    this.elements.presetBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        this.elements.amountInput.value = formatNumber(btn.dataset.value);
+        this.calculate();
+        btn.classList.add('loading'); setTimeout(() => btn.classList.remove('loading'), 300);
+      });
+    });
+    this.elements.termBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        this.elements.termBtns.forEach(b => { b.classList.remove('active'); b.setAttribute('aria-pressed', 'false'); });
+        btn.classList.add('active'); btn.setAttribute('aria-pressed', 'true');
+        this.state.days = parseInt(btn.dataset.days, 10);
+        this.calculate();
+      });
+    });
+  }
+  updateRateDisplay() {
+    const rate = parseFloat(this.elements.rateSlider.value);
+    this.elements.rateDisplay.textContent = `${rate.toFixed(1)}%`;
+  }
+  calculate() {
+    const amount = parseNumber(this.elements.amountInput.value);
+    const rate = parseFloat(this.elements.rateSlider.value) || 0;
+    const discount = amount * (rate / 100) * (this.state.days / 30);
+    const net = Math.max(0, amount - discount - this.state.fee);
+    this.animateValue(this.elements.sumAmount, amount, formatCurrency);
+    this.animateValue(this.elements.sumFinanced, amount, formatCurrency);
+    this.animateValue(this.elements.sumDiscount, discount, formatCurrency);
+    this.animateValue(this.elements.sumFee, this.state.fee, formatCurrency);
+    this.animateValue(this.elements.sumNet, net, formatCurrency);
+  }
+  animateValue(element, targetValue, formatter) {
+    const currentText = element.textContent.replace(/[^\d]/g, '');
+    const currentValue = parseInt(currentText || '0', 10) || 0;
+    const duration = 500, startTime = performance.now();
+    const animate = (t) => {
+      const progress = Math.min((t - startTime) / duration, 1);
+      const ease = 1 - Math.pow(1 - progress, 3);
+      const val = currentValue + (targetValue - currentValue) * ease;
+      element.textContent = formatter(Math.round(val));
+      if (progress < 1) requestAnimationFrame(animate);
+    };
+    requestAnimationFrame(animate);
+  }
+}
+
+// ==== Contadores ====
+class StatsCounter {
+  constructor() { this.hasAnimated = false; this.init(); }
+  init() {
+    const section = document.querySelector('.stats');
+    if (!section) return;
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting && !this.hasAnimated) { this.animateStats(); this.hasAnimated = true; }
+      });
+    }, { threshold: 0.5 });
+    observer.observe(section);
+  }
+  animateStats() {
+    document.querySelectorAll('.stat-value').forEach(el => {
+      const target = parseInt(el.dataset.target) || 0;
+      const prefix = el.dataset.prefix || '';
+      const suffix = el.dataset.suffix || '';
+      const duration = 2000, startTime = performance.now();
+      const step = (t) => {
+        const progress = Math.min((t - startTime) / duration, 1);
+        const ease = 1 - Math.pow(1 - progress, 3);
+        const current = Math.round(target * ease);
+        let display;
+        if (target >= 1_000_000_000) display = `${prefix}${(current / 1_000_000_000).toFixed(1)}B`;
+        else if (target >= 1_000_000) display = `${prefix}${(current / 1_000_000).toFixed(0)}M`;
+        else if (target >= 1_000) display = `${prefix}${(current / 1_000).toFixed(0)}K`;
+        else display = `${prefix}${current}${suffix}`;
+        el.textContent = display;
+        if (progress < 1) requestAnimationFrame(step);
+      };
+      requestAnimationFrame(step);
+    });
+  }
+}
+
+// ==== Header ====
+class HeaderController {
+  constructor(){ this.header = document.querySelector('.header'); this.lastScroll = 0; this.init(); }
+  init(){
+    if(!this.header) return;
+    window.addEventListener('scroll', () => this.handleScroll(), { passive: true });
+  }
+  handleScroll(){
+    const y = window.pageYOffset;
+    if (y > this.lastScroll && y > 100) this.header.classList.add('hidden'); else this.header.classList.remove('hidden');
+    if (y > 50) this.header.classList.add('scrolled'); else this.header.classList.remove('scrolled');
+    this.lastScroll = y;
+  }
+}
+
+// ==== Mobile Nav ====
+class MobileNav {
+  constructor(){ this.toggle = document.getElementById('mobileToggle'); this.nav = document.getElementById('mobileNav'); this.init(); }
+  init(){
+    if(!this.toggle || !this.nav) return;
+    this.toggle.addEventListener('click', () => this.toggleNav());
+    this.nav.addEventListener('click', (e) => { if (e.target.tagName === 'A') this.closeNav(); });
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && this.nav.classList.contains('open')) this.closeNav(); });
+  }
+  toggleNav(){ this.nav.classList.toggle('open'); this.toggle.setAttribute('aria-expanded', this.nav.classList.contains('open') ? 'true' : 'false'); this.toggle.innerHTML = this.nav.classList.contains('open') ? '<i class="fa-solid fa-xmark"></i>' : '<i class="fa-solid fa-bars"></i>'; }
+  closeNav(){ this.nav.classList.remove('open'); this.toggle.setAttribute('aria-expanded','false'); this.toggle.innerHTML = '<i class="fa-solid fa-bars"></i>'; }
+}
+
+// ==== Modal (focus trap y validación RUT) ====
+class ModalController {
+  constructor(){
+    this.modal = document.getElementById('loginModal');
+    this.openBtn = document.getElementById('loginToggle');
+    this.closeBtn = document.getElementById('loginClose');
+    this.form = document.getElementById('loginForm');
+    this.rutInput = document.getElementById('loginUser');
+    this.previouslyFocused = null;
+    this.keydownHandler = null;
+    this.init();
+  }
+  init(){
+    if(!this.modal) return;
+    this.openBtn?.addEventListener('click', () => this.openModal());
+    this.closeBtn?.addEventListener('click', () => this.closeModal());
+    this.modal.addEventListener('click', (e) => { if (e.target === this.modal) this.closeModal(); });
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !this.modal.classList.contains('hidden')) this.closeModal(); });
+
+    this.rutInput?.addEventListener('input', (e) => { e.target.value = formatRUT(e.target.value); });
+
+    this.form?.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const rutOk = validaRUT(this.rutInput.value);
+      const err = document.getElementById('rutError');
+      if(!rutOk){
+        err.classList.remove('sr-only'); err.textContent = 'RUT inválido. Revisa el dígito verificador.';
+        this.rutInput.focus(); return;
+      } else { err.classList.add('sr-only'); err.textContent=''; }
+      this.handleLogin();
+    });
+  }
+  openModal(){
+    this.previouslyFocused = document.activeElement;
+    this.modal.classList.remove('hidden');
+    this.modal.removeAttribute('hidden');
+    document.body.style.overflow = 'hidden';
+    // Focus trap
+    const focusables = this.modal.querySelectorAll('a,button,input,textarea,select,[tabindex]:not([tabindex="-1"])');
+    const first = focusables[0], last = focusables[focusables.length-1];
+    this.keydownHandler = (e)=>{
+      if(e.key==='Tab'){
+        if(e.shiftKey && document.activeElement===first){ e.preventDefault(); last.focus(); }
+        else if(!e.shiftKey && document.activeElement===last){ e.preventDefault(); first.focus(); }
+      }
+    };
+    this.modal.addEventListener('keydown', this.keydownHandler);
+    setTimeout(()=> this.rutInput?.focus(), 100);
+  }
+  closeModal(){
+    this.modal.classList.add('hidden');
+    this.modal.setAttribute('hidden','');
+    document.body.style.overflow = '';
+    if (this.keydownHandler) this.modal.removeEventListener('keydown', this.keydownHandler);
+    this.openBtn?.focus();
+  }
+  handleLogin(){
+    const submitBtn = this.form.querySelector('button[type="submit"]');
+    const original = submitBtn.innerHTML;
+    submitBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Verificando...';
+    submitBtn.disabled = true;
+    setTimeout(() => {
+      alert('Portal de clientes próximamente disponible. Te notificaremos cuando esté listo.');
+      this.form.reset(); this.closeModal();
+      submitBtn.innerHTML = original; submitBtn.disabled = false;
+    }, 1500);
+  }
+}
+
+// ==== Contacto ====
+class ContactForm {
+  constructor(){ this.form = document.getElementById('contactForm'); this.init(); }
+  init(){
+    if(!this.form) return;
+    this.form.addEventListener('submit', (e) => { e.preventDefault(); this.handleSubmit(); });
+  }
+  handleSubmit(){
+    const submitBtn = this.form.querySelector('button[type="submit"]');
+    const original = submitBtn.innerHTML;
+    submitBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Enviando...'; submitBtn.disabled = true;
+    setTimeout(() => {
+      alert('¡Gracias por tu mensaje! Nos pondremos en contacto contigo dentro de las próximas 24 horas.');
+      this.form.reset(); submitBtn.innerHTML = original; submitBtn.disabled = false;
+    }, 2000);
+  }
+}
+
+// ==== Galería ====
+class Gallery {
+  constructor(){ this.slides = document.querySelectorAll('.gallery img'); this.currentSlide = 0; this.init(); }
+  init(){ if (this.slides.length === 0) return; setInterval(() => this.nextSlide(), 5000); }
+  nextSlide(){ this.slides[this.currentSlide].classList.remove('active'); this.currentSlide = (this.currentSlide + 1) % this.slides.length; this.slides[this.currentSlide].classList.add('active'); }
+}
+
+// ==== Reveal ====
+class RevealAnimations {
+  constructor(){ this.elements = document.querySelectorAll('.reveal'); this.init(); }
+  init(){
+    const observer = new IntersectionObserver((entries, ob) => {
+      entries.forEach(entry => { if(entry.isIntersecting){ entry.target.classList.add('visible'); ob.unobserve(entry.target); } });
+    }, { threshold: 0.1, rootMargin: '0px 0px -50px 0px' });
+    this.elements.forEach(el => observer.observe(el));
+  }
+}
+
+// ==== Scroll suave (no bloquear enlaces sin destino) ====
+class SmoothScroll {
+  constructor(){ this.init(); }
+  init(){
+    document.addEventListener('click', (e) => {
+      const link = e.target.closest('a[href^="#"]');
+      if (!link) return;
+      const targetId = link.getAttribute('href');
+      if (!targetId || targetId === '#') return;
+      const target = document.querySelector(targetId);
+      if (!target) return;
+      e.preventDefault();
+      const headerHeight = document.querySelector('.header')?.offsetHeight || 80;
+      const y = target.offsetTop - headerHeight - 20;
+      window.scrollTo({ top: y, behavior: 'smooth' });
+    });
+  }
+}
+
+// ==== App ====
+class App {
+  constructor(){ this.init(); }
+  init(){
+    new Calculator();
+    new StatsCounter();
+    new HeaderController();
+    new MobileNav();
+    new ModalController();
+    new ContactForm();
+    new Gallery();
+    new RevealAnimations();
+    new SmoothScroll();
+
+    document.getElementById('btnFirmaDocsTop')?.addEventListener('click', () => {
+      alert('Portal de firma digital próximamente disponible. Te notificaremos cuando esté listo.');
+    });
+    document.getElementById('btnConoceNos')?.addEventListener('click', () => {
+      document.querySelector('#proceso')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+
+    this.optimizeImages();
+  }
+  optimizeImages(){
+    const images = document.querySelectorAll('img[src]');
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) { entry.target.classList.add('loaded'); io.unobserve(entry.target); }
+      });
+    });
+    images.forEach(img => io.observe(img));
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => new App());
+} else { new App(); }
+
+window.addEventListener('error', (e) => { console.error('Error en la aplicación:', e.error); });
+
+// Service worker: solo registra si existe /sw.js en el origen
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    fetch('/sw.js', { method: 'HEAD' }).then(r => {
+      if (r.ok) navigator.serviceWorker.register('/sw.js').catch(()=>{});
+    }).catch(()=>{});
+  });
+}
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,272 +1,648 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.acfcapital.cl data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self'; connect-src 'self';" />
-  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
-  <meta http-equiv="X-Frame-Options" content="DENY" />
-
-  <title>ACF Capital - Factoring</title>
-  <link rel="stylesheet" href="styles.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content=
+  "width=device-width, initial-scale=1.0">
+  <meta name="description" content=
+  "ACF Capital - Factoring empresarial con liquidez inmediata. Anticipa tus facturas con tasas competitivas y proceso simple.">
+  <!-- CSP endurecida con nonce (usa un valor aleatorio distinto por respuesta HTTP) -->
+  <!-- Ejemplo de nonce fijo SOLO para demo: abc123. En producción genera y reemplaza dinámicamente -->
+  <meta http-equiv="Content-Security-Policy" content=
+  "default-src 'self'; img-src 'self' https://www.acfcapital.cl data:; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self' 'nonce-abc123'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <title>ACF Capital - Factoring Empresarial | Liquidez
+  Inmediata</title>
+  <link href=
+  "https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;display=swap"
+  rel="stylesheet">
+  <!-- Sugerido: agregar SRI válido para el archivo exacto de Font Awesome que uses -->
+  <link rel="stylesheet" href=
+  "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+  <link rel="stylesheet" href="./styles.css">
 </head>
 <body>
-  <header class="navbar">
+  <a href="#main-content" class="skip-link">Saltar al contenido
+  principal</a>
+  <header class="header" role="banner">
     <div class="container">
-      <img src="logo_acf.svg" alt="ACF Capital" class="logo" />
-      <nav class="main-nav">
-        <a href="#nosotros">Nosotros</a>
-        <a href="#servicios">Servicios</a>
-        <a href="#como-funciona">Cómo funciona</a>
-        <a href="#simulador">Simulador</a>
-        <a href="#oficinas">Oficinas</a>
-        <a href="#contacto">Contacto</a>
-      </nav>
-      <div class="nav-actions">
-        <button id="btnFirmaDocsTop" class="btn-secondary btn-nav">Firmar documentos</button>
-        <button id="loginToggle" class="btn-accent btn-nav"><i class="fa-solid fa-user"></i> Acceso clientes</button>
+      <div class="header-content">
+        <!-- Logo: mantener sin lazy por ser visible en el primer pantallazo -->
+        <img src="./logo_acf.svg" alt="ACF Capital" class="logo"
+        width="250" height="48">
+        <nav class="nav-main" role="navigation" aria-label="Navegación principal">
+          <a href="#nosotros">Nosotros</a>
+          <a href="#servicios">Servicios</a>
+          <a href="#proceso">Proceso</a>
+          <a href="#simulador">Simulador</a>
+          <a href="#oficinas">Oficinas</a>
+          <a href="#contacto">Contacto</a>
+        </nav>
+        <div class="nav-actions">
+          <button class="btn btn-secondary" id="btnFirmaDocsTop" aria-label="Acceder a firma de documentos">
+            <i class="fa-solid fa-file-signature" aria-hidden="true"></i>
+            Firmar docs
+          </button>
+          <button class="btn btn-primary" id="loginToggle" aria-label="Acceso para clientes">
+            <i class="fa-solid fa-user" aria-hidden="true"></i>
+            Acceso clientes
+          </button>
+        </div>
+        <button class="mobile-toggle" id="mobileToggle" aria-label="Abrir menú de navegación" aria-expanded="false">
+          <i class="fa-solid fa-bars" aria-hidden="true"></i>
+        </button>
       </div>
+      <nav class="mobile-nav" id="mobileNav" role="navigation"
+      aria-label="Navegación móvil">
+        <a href="#nosotros">Nosotros</a> <a href=
+        "#servicios">Servicios</a> <a href="#proceso">Proceso</a>
+        <a href="#simulador">Simulador</a> <a href=
+        "#oficinas">Oficinas</a> <a href="#contacto">Contacto</a>
+      </nav>
     </div>
   </header>
-
-  <div id="loginModal" class="modal hidden" hidden role="dialog" aria-modal="true">
-    <div class="modal-content">
-      <button id="loginClose" class="modal-close" aria-label="Cerrar">&times;</button>
-      <form id="loginForm" class="login-form">
-        <h3>Bienvenido a ACF Capital</h3>
-        <label for="loginUser">RUT</label>
-        <input type="text" id="loginUser" required />
-        <label for="loginPass">Contraseña</label>
-        <input type="password" id="loginPass" required />
-        <button type="submit" class="btn-login">Aceptar</button>
-        <a href="#" class="forgot-link">¿Olvidaste tu clave?</a>
-      </form>
-    </div>
-  </div>
-
-  <section class="hero">
-    <div class="container hero-grid">
-      <div class="hero-text">
-        <h1>Liquidez inmediata para tu empresa</h1>
-        <p>Anticipa tus facturas con tasas competitivas y un proceso simple.</p>
-        <a href="#simulador" class="btn-primary">Simular Factoring</a>
-      </div>
-      <div class="hero-image">
-        <div class="gallery">
-          <img src="https://www.acfcapital.cl/acfcapital/images/fondo_preguntas_frec.jpg?crc=53158438" alt="Preguntas frecuentes" class="active" />
-          <img src="https://www.acfcapital.cl/acfcapital/images/fondo_c.jpg?crc=404174028" alt="Fondo corporativo C" />
-          <img src="https://www.acfcapital.cl/acfcapital/images/fondo_b.jpg?crc=4148428054" alt="Fondo corporativo B" />
-          <img src="https://www.acfcapital.cl/acfcapital/images/fondo_a.jpg?crc=3944499221" alt="Fondo corporativo A" />
+  <main id="main-content">
+    <section class="hero" role="banner">
+      <div class="container">
+        <div class="hero-content reveal">
+          <div class="hero-text">
+            <h1>Liquidez inmediata para hacer crecer tu
+            empresa</h1>
+            <p class="hero-subtitle">Transforma tus facturas en
+            efectivo con nuestro servicio de factoring. Proceso
+            100% digital, respuesta en 24 horas y las mejores tasas
+            del mercado.</p>
+            <div class="hero-cta">
+              <a href="#simulador" class="btn btn-primary">
+                <i class="fa-solid fa-calculator" aria-hidden="true"></i>
+                Simular ahora
+              </a>
+              <button class="btn btn-ghost" id="btnConoceNos">
+                <i class="fa-solid fa-play" aria-hidden="true"></i>
+                Conoce cómo funciona
+              </button>
+            </div>
+          </div>
+          <div class="hero-image" aria-hidden="true">
+            <div class="gallery" role="img" aria-label=
+            "Galería de imágenes corporativas">
+            <!-- LCP candidate con mayor prioridad -->
+            <img src=
+            "https://www.acfcapital.cl/acfcapital/images/fondo_preguntas_frec.jpg?crc=53158438"
+            alt="Equipo profesional trabajando" class="active"
+            width="1600" height="900" fetchpriority="high"
+            decoding="async"> <!-- Resto con lazy -->
+             <img src=
+            "https://www.acfcapital.cl/acfcapital/images/fondo_c.jpg?crc=404174028"
+            alt="Oficina moderna" loading="lazy" width="1600"
+            height="900" decoding="async"> <img src=
+            "https://www.acfcapital.cl/acfcapital/images/fondo_b.jpg?crc=4148428054"
+            alt="Tecnología financiera" loading="lazy" width="1600"
+            height="900" decoding="async"> <img src=
+            "https://www.acfcapital.cl/acfcapital/images/fondo_a.jpg?crc=3944499221"
+            alt="Crecimiento empresarial" loading="lazy" width=
+            "1600" height="900" decoding="async"></div>
+          </div>
         </div>
       </div>
-    </div>
     </section>
-
-    <section id="nosotros" class="stats reveal">
+    <section id="nosotros" class="stats reveal" aria-labelledby=
+    "stats-title">
       <div class="container">
-        <h2>Nosotros</h2>
+        <h2 id="stats-title">Respaldados por resultados</h2>
         <div class="stats-grid">
-          <div class="stats-card">
-            <p class="stat-value">+500</p>
-            <p class="stat-label">Clientes activos</p>
+          <div class="stat-card">
+            <div class="stat-value" data-target="500">
+              0
+            </div>
+            <div class="stat-label">
+              Clientes activos
+            </div>
           </div>
-          <div class="stats-card">
-            <p class="stat-value">US$7B</p>
-            <p class="stat-label">Financiamiento cursado</p>
+          <div class="stat-card">
+            <div class="stat-value" data-target="7000000000"
+            data-prefix="US$" data-suffix="">
+              0
+            </div>
+            <div class="stat-label">
+              Financiamiento cursado
+            </div>
           </div>
-          <div class="stats-card">
-            <p class="stat-value">24h</p>
-            <p class="stat-label">Respuesta promedio</p>
+          <div class="stat-card">
+            <div class="stat-value" data-target="24" data-suffix=
+            "h">
+              0
+            </div>
+            <div class="stat-label">
+              Tiempo de respuesta
+            </div>
           </div>
-          <div class="stats-card">
-            <p class="stat-value">15+</p>
-            <p class="stat-label">Años de experiencia</p>
+          <div class="stat-card">
+            <div class="stat-value" data-target="15" data-suffix=
+            "+">
+              0
+            </div>
+            <div class="stat-label">
+              Años de experiencia
+            </div>
           </div>
         </div>
       </div>
     </section>
-
-    <section id="servicios" class="services reveal">
-    <div class="container">
-      <h2>Nuestros servicios</h2>
-      <div class="cards">
-        <div class="card">
-          <i class="fa-solid fa-coins icon"></i>
-          <h3>Anticipo de fondos</h3>
-          <p>Compramos tus cuentas por cobrar y te entregamos efectivo al contado.</p>
-        </div>
-        <div class="card">
-          <i class="fa-solid fa-hand-holding-dollar icon"></i>
-          <h3>Cobranza</h3>
-          <p>Gestionamos tus documentos con profesionales y tecnología de punta.</p>
-        </div>
-        <div class="card">
-          <i class="fa-solid fa-globe icon"></i>
-          <h3>Información en línea</h3>
-          <p>Accede a la actualización de tus operaciones en nuestro sitio web.</p>
-        </div>
-        <div class="card">
-          <i class="fa-solid fa-eye-slash icon"></i>
-          <h3>Factoring sin notificación</h3>
-          <p>Obtén liquidez sin afectar la relación con tu cliente.</p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-    <section id="como-funciona" class="how-it-works reveal">
-    <div class="container">
-      <h2>¿Cómo funciona?</h2>
-      <div class="how-grid">
-        <div>
-          <i class="fa-solid fa-upload icon"></i>
-          <h3>1. Sube tu factura</h3>
-          <p>Envíanos la documentación mediante nuestro portal.</p>
-        </div>
-        <div>
-          <i class="fa-solid fa-check-circle icon"></i>
-          <h3>2. Evaluamos y aprobamos</h3>
-          <p>Recibes respuesta en menos de 24 horas.</p>
-        </div>
-        <div>
-          <i class="fa-solid fa-money-bill-wave icon"></i>
-          <h3>3. Recibe tu dinero</h3>
-          <p>Transferimos los fondos a tu cuenta bancaria.</p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section class="calculator reveal" id="simulador">
-    <div class="container">
-      <p class="tagline">Cobra hoy tus facturas con factoring</p>
-      <h2>Simula tu primer financiamiento</h2>
-      <div class="calc-wrapper">
-        <form id="calcForm" class="calc-form">
-          <label for="invoiceAmount">Monto de la(s) factura(s) que quieres adelantar</label>
-          <div class="amount-input">
-            <span class="currency">CLP $</span>
-            <input type="text" id="invoiceAmount" value="1.000.000" inputmode="numeric" />
-          </div>
-          <div class="preset-amounts">
-            <button type="button" data-value="50000">50K</button>
-            <button type="button" data-value="500000">500K</button>
-            <button type="button" data-value="1000000">1M</button>
-            <button type="button" data-value="5000000">5M</button>
-          </div>
-          <p>Plazo de pago de la factura</p>
-          <div class="term-buttons">
-            <button type="button" data-days="30" class="active">30 días</button>
-            <button type="button" data-days="60">60 días</button>
-            <button type="button" data-days="90">90 días</button>
-            <button type="button" data-days="120">120 días</button>
-            <button type="button" data-days="150">150 días</button>
-          </div>
-          <label for="rate">Tasa de interés mensual: <span id="rateValue">0.9%</span></label>
-          <input type="range" id="rate" min="0" max="5" step="0.1" value="0.9" />
-        </form>
-        <div class="calc-summary">
-          <p>Monto facturas por financiar <span id="sumAmount"></span></p>
-          <p>Monto financiado (100%) <span id="sumFinanced"></span></p>
-          <p>Comisión de factoring <span id="sumDiscount"></span></p>
-          <p>Gastos de la operación <span id="sumFee"></span></p>
-          <p class="result">Hoy puedes cobrar <span id="sumNet"></span></p>
-          <a href="#contacto" class="btn-accent">Contáctanos</a>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section id="oficinas" class="offices reveal">
-    <div class="container">
-      <h2>Nuestras Oficinas</h2>
-      <div class="offices-grid">
-        <div>
-          <p><strong>Antofagasta</strong><br />Arturo Prat 461 Of. 1802<br />55 2251 340</p>
-          <p><strong>Copiapó</strong><br />clezcano@acfcapital.cl<br />2 23389400</p>
-          <p><strong>Santiago, Casa Matriz</strong><br />Av. El Bosque Norte 0177 Of. 802<br />Las Condes<br />22338 9400</p>
-          <p><strong>Santiago, Providencia</strong><br />Av. Providencia 2653 Of. 1102<br />Providencia<br />22520 6000 - 22233 2469</p>
-        </div>
-        <div>
-          <p><strong>Viña del Mar</strong><br />Av. Nueva libertad 1405 Of.1306<br />32 2690 759</p>
-          <p><strong>Rancagua</strong><br />eguajardo@acfcapital.cl<br />2 23389400</p>
-          <p><strong>Puerto Montt</strong><br />Benavente 550 Of. 503<br />65 2348 910</p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section id="contacto" class="contact reveal">
-    <div class="container">
-      <h2>Contáctanos</h2>
-      <p class="address">Av. El Bosque Norte 0177 Of. 802, Las Condes, Santiago.</p>
-      <form id="contactForm" class="contact-form">
-        <label>Nombre
-          <input type="text" id="name" required />
-        </label>
-        <label>Correo
-          <input type="email" id="email" required />
-        </label>
-        <label>Mensaje
-          <textarea id="message" rows="4"></textarea>
-        </label>
-      <button type="submit" class="btn-primary">Enviar</button>
-      </form>
-    </div>
-  </section>
-
-  <footer class="site-footer">
-    <div class="footer-top container">
-      <div class="footer-brand">
-        <img src="logo_acf.svg" alt="ACF Capital" class="footer-logo" />
-        <p>Financiamiento ágil y confiable para tu empresa.</p>
-      </div>
-      <div class="footer-links">
-        <div class="footer-column">
-          <h4>Servicios</h4>
-          <ul>
-            <li><a href="#servicios">Anticipo de fondos</a></li>
-            <li><a href="#servicios">Cobranza</a></li>
-            <li><a href="#servicios">Información en línea</a></li>
-            <li><a href="#servicios">Factoring sin notificación</a></li>
-          </ul>
-        </div>
-        <div class="footer-column">
-          <h4>Recursos</h4>
-          <ul>
-            <li><a href="#simulador">Calculadora</a></li>
-            <li><a href="#contacto">Contacto</a></li>
-            <li><a href="#">Preguntas frecuentes</a></li>
-            <li><a href="#">Blog</a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-    <div class="footer-bottom">
+    <section id="servicios" class="services reveal"
+    aria-labelledby="services-title">
       <div class="container">
+        <h2 id="services-title">Nuestros servicios</h2>
+        <p class="services-subtitle">Soluciones financieras
+        integrales diseñadas para impulsar el crecimiento de tu
+        empresa</p>
+        <div class="services-grid">
+          <article class="service-card">
+            <div class="service-icon" aria-hidden="true">
+              <i class="fa-solid fa-coins"></i>
+            </div>
+            <h3>Anticipo de fondos</h3>
+            <p>Compramos tus cuentas por cobrar y te entregamos
+            efectivo inmediatamente. Sin esperas, sin
+            complicaciones.</p>
+          </article>
+          <article class="service-card">
+            <div class="service-icon" aria-hidden="true">
+              <i class="fa-solid fa-hand-holding-dollar"></i>
+            </div>
+            <h3>Gestión de cobranza</h3>
+            <p>Nuestro equipo especializado gestiona el cobro de
+            tus documentos con la más alta tecnología y
+            profesionalismo.</p>
+          </article>
+          <article class="service-card">
+            <div class="service-icon" aria-hidden="true">
+              <i class="fa-solid fa-chart-line"></i>
+            </div>
+            <h3>Plataforma digital</h3>
+            <p>Accede en tiempo real al estado de todas tus
+            operaciones a través de nuestra plataforma web
+            intuitiva.</p>
+          </article>
+          <article class="service-card">
+            <div class="service-icon" aria-hidden="true">
+              <i class="fa-solid fa-eye-slash"></i>
+            </div>
+            <h3>Factoring confidencial</h3>
+            <p>Obtén liquidez sin que tus clientes se enteren,
+            manteniendo intacta la relación comercial.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+    <section id="proceso" class="process reveal" aria-labelledby=
+    "process-title">
+      <div class="container">
+        <h2 id="process-title">¿Cómo funciona?</h2>
+        <p class="process-subtitle">Un proceso simple y rápido en
+        solo 3 pasos</p>
+        <div class="process-grid">
+          <article class="process-step">
+            <div class="step-number">1</div>
+            <div class="step-icon" aria-hidden="true">
+              <i class="fa-solid fa-upload"></i>
+            </div>
+            <h3>Envía tu documentación</h3>
+            <p>Sube tus facturas y documentos a través de nuestra
+            plataforma segura. El proceso es 100% digital.</p>
+          </article>
+          <article class="process-step">
+            <div class="step-number">2</div>
+            <div class="step-icon" aria-hidden="true">
+              <i class="fa-solid fa-magnifying-glass-chart"></i>
+            </div>
+            <h3>Evaluamos tu solicitud</h3>
+            <p>Nuestro equipo analiza tu documentación y te da una
+            respuesta en menos de 24 horas hábiles.</p>
+          </article>
+          <article class="process-step">
+            <div class="step-number">3</div>
+            <div class="step-icon" aria-hidden="true">
+              <i class="fa-solid fa-money-bill-transfer"></i>
+            </div>
+            <h3>Recibe tu dinero</h3>
+            <p>Una vez aprobado, transferimos los fondos
+            directamente a tu cuenta bancaria de forma segura.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+    <section id="simulador" class="calculator reveal"
+    aria-labelledby="calc-title">
+      <div class="container">
+        <div class="calculator-header">
+          <p class="calculator-tagline">Simulador de factoring</p>
+          <h2 id="calc-title">Calcula tu financiamiento</h2>
+          <p class="calculator-subtitle">Descubre cuánto puedes
+          obtener hoy por tus facturas pendientes</p>
+        </div>
+        <div class="calc-container">
+          <form class="calc-form" id="calcForm" aria-label=
+          "Formulario de simulación de factoring" novalidate=""
+          name="calcForm">
+            <div class="form-group">
+              <label for="invoiceAmount" class="form-label">Monto
+              total de facturas a financiar</label>
+              <div class="amount-wrapper">
+                <span class="currency-symbol" aria-label=
+                "Pesos chilenos">CLP $</span> <input type="text"
+                id="invoiceAmount" class="amount-input" value=
+                "1.000.000" inputmode="numeric" aria-describedby=
+                "amount-help" required="">
+              </div>
+              <div id="amount-help" class="sr-only">
+                Ingresa el monto en pesos chilenos que deseas
+                financiar
+              </div>
+              <div class="preset-buttons" role="group" aria-label=
+              "Montos predefinidos">
+                <button type="button" class="preset-btn"
+                data-value="50000">$50K</button> <button type=
+                "button" class="preset-btn" data-value=
+                "500000">$500K</button> <button type="button"
+                class="preset-btn" data-value=
+                "1000000">$1M</button> <button type="button" class=
+                "preset-btn" data-value="5000000">$5M</button>
+                <button type="button" class="preset-btn"
+                data-value="10000000">$10M</button>
+              </div>
+            </div>
+            <div class="form-group">
+              <fieldset>
+                <legend class="term-label">Plazo de pago de las
+                facturas</legend>
+                <div class="term-buttons" role="group" aria-label=
+                "Selección de plazo">
+                  <button type="button" class="term-btn active"
+                  data-days="30" aria-pressed="true">30
+                  días</button> <button type="button" class=
+                  "term-btn" data-days="60" aria-pressed="false">60
+                  días</button> <button type="button" class=
+                  "term-btn" data-days="90" aria-pressed="false">90
+                  días</button> <button type="button" class=
+                  "term-btn" data-days="120" aria-pressed=
+                  "false">120 días</button> <button type="button"
+                  class="term-btn" data-days="150" aria-pressed=
+                  "false">150 días</button>
+                </div>
+              </fieldset>
+            </div>
+            <div class="form-group rate-group">
+              <label for="rate" class="rate-label"><span>Tasa de
+              interés mensual <span aria-hidden="true">•</span>
+              <small>(referencial)</small></span> <span class=
+              "rate-value" id="rateDisplay">0.9%</span></label>
+              <input type="range" id="rate" class="rate-slider"
+              min="0.5" max="4.5" step="0.1" value="0.9"
+              aria-describedby="rate-help">
+              <div id="rate-help" class="sr-only">
+                Ajusta la tasa de interés mensual entre 0.5% y 4.5%
+              </div>
+            </div>
+          </form>
+          <div class="calc-results" role="region" aria-labelledby=
+          "results-title" aria-live="polite">
+            <h3 id="results-title" class="results-title">Resumen de
+            tu operación</h3>
+            <div class="result-row">
+              <span class="result-label">Monto a financiar:</span>
+              <span class="result-value" id="sumAmount">$0</span>
+            </div>
+            <div class="result-row">
+              <span class="result-label">Financiamiento
+              (100%):</span> <span class="result-value" id=
+              "sumFinanced">$0</span>
+            </div>
+            <div class="result-row">
+              <span class="result-label">Comisión de
+              factoring:</span> <span class="result-value" id=
+              "sumDiscount">$0</span>
+            </div>
+            <div class="result-row">
+              <span class="result-label">Gastos
+              operacionales:</span> <span class="result-value" id=
+              "sumFee">$0</span>
+            </div>
+            <div class="final-result">
+              <div class="result-label">
+                Recibes hoy
+              </div>
+              <div class="result-value" id="sumNet">
+                $0
+              </div>
+            </div>
+            <a href="#contacto" class="btn btn-primary" style="width: 100%; margin-top: 1rem;">
+              <i class="fa-solid fa-phone" aria-hidden="true"></i>
+              Solicitar financiamiento
+            </a>
+            <p style=
+            "margin-top: .75rem; font-size:.85rem; opacity:.9">*
+            Cálculo referencial. Tasas, comisiones y gastos sujetos
+            a evaluación y podrían variar.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section id="oficinas" class="offices reveal" aria-labelledby=
+    "offices-title">
+      <div class="container">
+        <h2 id="offices-title">Nuestras oficinas</h2>
+        <div class="offices-grid">
+          <article class="office-card">
+            <h3 class="office-title">Santiago - Casa Matriz</h3>
+            <address class="office-address">
+              Av. El Bosque Norte 0177, Oficina 802<br>
+              Las Condes, Santiago
+            </address>
+            <div class="office-contact">
+              <i class="fa-solid fa-phone" aria-hidden="true"></i>
+              <a href="tel:+56223389400">+56 2 2338 9400</a>
+            </div>
+          </article>
+          <article class="office-card">
+            <h3 class="office-title">Santiago - Providencia</h3>
+            <address class="office-address">
+              Av. Providencia 2653, Oficina 1102<br>
+              Providencia, Santiago
+            </address>
+            <div class="office-contact">
+              <i class="fa-solid fa-phone" aria-hidden="true"></i>
+              <a href="tel:+56225206000">+56 2 2520 6000</a>
+            </div>
+          </article>
+          <article class="office-card">
+            <h3 class="office-title">Antofagasta</h3>
+            <address class="office-address">
+              Arturo Prat 461, Oficina 1802<br>
+              Antofagasta
+            </address>
+            <div class="office-contact">
+              <i class="fa-solid fa-phone" aria-hidden="true"></i>
+              <a href="tel:+56552251340">+56 55 2251 340</a>
+            </div>
+          </article>
+          <article class="office-card">
+            <h3 class="office-title">Viña del Mar</h3>
+            <address class="office-address">
+              Av. Nueva Libertad 1405, Oficina 1306<br>
+              Viña del Mar
+            </address>
+            <div class="office-contact">
+              <i class="fa-solid fa-phone" aria-hidden="true"></i>
+              <a href="tel:+56322690759">+56 32 2690 759</a>
+            </div>
+          </article>
+          <article class="office-card">
+            <h3 class="office-title">Puerto Montt</h3>
+            <address class="office-address">
+              Benavente 550, Oficina 503<br>
+              Puerto Montt
+            </address>
+            <div class="office-contact">
+              <i class="fa-solid fa-phone" aria-hidden="true"></i>
+              <a href="tel:+56652348910">+56 65 2348 910</a>
+            </div>
+          </article>
+          <article class="office-card">
+            <h3 class="office-title">Copiapó</h3>
+            <address class="office-address">
+              Consultas regionales
+            </address>
+            <div class="office-contact">
+              <i class="fa-solid fa-envelope" aria-hidden="true"></i>
+              <a href="mailto:clezcano@acfcapital.cl">clezcano@acfcapital.cl</a>
+            </div>
+          </article><!-- NUEVA: Rancagua -->
+          <article class="office-card">
+            <h3 class="office-title">Rancagua</h3>
+            <address class="office-address">
+              Consultas regionales
+            </address>
+            <div class="office-contact">
+              <i class="fa-solid fa-envelope" aria-hidden="true"></i>
+              <a href="mailto:eguajardo@acfcapital.cl">eguajardo@acfcapital.cl</a>
+            </div>
+            <div class="office-contact" style="margin-top:.5rem">
+              <i class="fa-solid fa-phone" aria-hidden="true"></i>
+              <a href="tel:+56223389400">+56 2 2338 9400</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+    <section id="contacto" class="contact reveal" aria-labelledby=
+    "contact-title">
+      <div class="container">
+        <h2 id="contact-title">Hablemos de tu proyecto</h2>
+        <p class="contact-subtitle">Nuestro equipo está listo para
+        ayudarte a encontrar la mejor solución de
+        financiamiento</p>
+        <form class="contact-form" id="contactForm" aria-label=
+        "Formulario de contacto" novalidate="" name="contactForm">
+          <div class="input-group">
+            <label for="contactName" class="input-label">Nombre
+            completo *</label> <input type="text" id="contactName"
+            class="form-input" required="" aria-required="true"
+            autocomplete="name">
+          </div>
+          <div class="input-group">
+            <label for="contactEmail" class="input-label">Correo
+            electrónico *</label> <input type="email" id=
+            "contactEmail" class="form-input" required=""
+            aria-required="true" autocomplete="email">
+          </div>
+          <div class="input-group">
+            <label for="contactPhone" class=
+            "input-label">Teléfono</label> <input type="tel" id=
+            "contactPhone" class="form-input" autocomplete="tel">
+          </div>
+          <div class="input-group">
+            <label for="contactMessage" class=
+            "input-label">Mensaje</label> 
+            <textarea id="contactMessage" class=
+            "form-input form-textarea" rows="4" placeholder=
+            "Cuéntanos sobre tu empresa y necesidades de financiamiento...">
+            </textarea>
+          </div>
+          <button type="submit" class="btn btn-primary" style="width: 100%;">
+            <i class="fa-solid fa-paper-plane" aria-hidden="true"></i>
+            Enviar mensaje
+          </button>
+        </form>
+      </div>
+    </section>
+  </main>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <div class="footer-content">
+        <div class="footer-brand">
+          <h3>ACF Capital</h3>
+          <p>Más de 15 años proporcionando soluciones de factoring
+          ágiles y confiables para empresas de todos los tamaños en
+          Chile.</p>
+        </div>
+        <div class="footer-section">
+          <h4>Servicios</h4>
+          <ul class="footer-links">
+            <li>
+              <a href="#servicios">Anticipo de fondos</a>
+            </li>
+            <li>
+              <a href="#servicios">Gestión de cobranza</a>
+            </li>
+            <li>
+              <a href="#servicios">Plataforma digital</a>
+            </li>
+            <li>
+              <a href="#servicios">Factoring confidencial</a>
+            </li>
+          </ul>
+        </div>
+        <div class="footer-section">
+          <h4>Recursos</h4>
+          <ul class="footer-links">
+            <li>
+              <a href="#simulador">Calculadora</a>
+            </li>
+            <li>
+              <a href="#contacto">Contacto</a>
+            </li>
+            <li>
+              <a href="#oficinas">Oficinas</a>
+            </li>
+            <li>
+              <a href="#proceso">Cómo funciona</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
         <p>© 2025 ACF Capital. Todos los derechos reservados.</p>
-        <nav class="footer-legal">
-          <a href="#">Privacidad</a>
-          <a href="#">Términos</a>
-          <a href="#">Compliance</a>
-          <a href="#">Mapa del sitio</a>
+        <nav class="footer-legal" aria-label="Enlaces legales">
+          <a href="/privacidad" aria-label=
+          "Política de privacidad">Privacidad</a> <a href=
+          "/terminos" aria-label=
+          "Términos y condiciones">Términos</a> <a href=
+          "/compliance" aria-label="Compliance">Compliance</a>
+          <a href="/sitemap.xml" aria-label="Mapa del sitio">Mapa
+          del sitio</a>
         </nav>
       </div>
     </div>
-  </footer>
-
-  <a
-    href="https://api.whatsapp.com/send?phone=56985963134&text=Hola!%20Quiero%20hacer%20una%20consulta."
-    class="whatsapp-btn"
-    target="_blank"
-    rel="noopener"
-    aria-label="WhatsApp"
-  >
-    <i class="fa-brands fa-whatsapp"></i>
+  </footer><!-- WhatsApp Button -->
+  <a href="https://api.whatsapp.com/send?phone=56985963134&amp;text=Hola!%20Quiero%20hacer%20una%20consulta%20sobre%20factoring."
+  class="whatsapp-btn" target="_blank" rel="noopener noreferrer" aria-label="Contactar por WhatsApp">
+    <i class="fa-brands fa-whatsapp" aria-hidden="true"></i>
   </a>
+  <!-- Login Modal -->
+  <div id="loginModal" class="modal hidden" role="dialog"
+  aria-labelledby="login-title" aria-modal="true">
+    <div class="modal-content">
+      <button id="loginClose" class="modal-close" aria-label="Cerrar ventana de acceso">
+        <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+      </button>
+      <form id="loginForm" class="login-form" aria-label=
+      "Formulario de acceso clientes" novalidate="" name=
+      "loginForm">
+        <h3 id="login-title">Acceso clientes</h3>
+        <div class="input-group">
+          <label for="loginUser" class="input-label">RUT</label>
+          <input type="text" id="loginUser" class="form-input"
+          placeholder="12.345.678-9" required="" aria-required=
+          "true" autocomplete="username" inputmode="text">
+          <div id="rutError" class="sr-only" aria-live="assertive">
+          </div>
+        </div>
+        <div class="input-group">
+          <label for="loginPass" class=
+          "input-label">Contraseña</label> <input type="password"
+          id="loginPass" class="form-input" required=""
+          aria-required="true" autocomplete="current-password">
+        </div>
+        <button type="submit" class="btn btn-primary" style="width: 100%;">
+          <i class="fa-solid fa-sign-in-alt" aria-hidden="true"></i>
+          Ingresar
+        </button>
+        <a href="/recuperar-clave" class="forgot-link">¿Olvidaste tu contraseña?</a>
+      </form>
+    </div>
+  </div><!-- JSON-LD: Organización y sucursales -->
+  <script type="application/ld+json" nonce="abc123">
+  {
+    "@context": "https://schema.org",
+    "@type": "FinancialService",
+    "name": "ACF Capital",
+    "url": "https://www.acfcapital.cl",
+    "logo": "https://www.acfcapital.cl/logo.png",
+    "areaServed": "CL",
+    "serviceType": ["Factoring", "Factoring confidencial"],
+    "department": [
+      {
+        "@type":"LocalBusiness",
+        "name":"Casa Matriz Santiago",
+        "address":{"@type":"PostalAddress","streetAddress":"Av. El Bosque Norte 0177, Oficina 802","addressLocality":"Las Condes","addressRegion":"RM","addressCountry":"CL"},
+        "telephone":"+56-2-2338-9400"
+      },
+      {
+        "@type":"LocalBusiness",
+        "name":"Santiago - Providencia",
+        "address":{"@type":"PostalAddress","streetAddress":"Av. Providencia 2653, Oficina 1102","addressLocality":"Providencia","addressRegion":"RM","addressCountry":"CL"},
+        "telephone":"+56-2-2520-6000"
+      },
+      {
+        "@type":"LocalBusiness",
+        "name":"Antofagasta",
+        "address":{"@type":"PostalAddress","streetAddress":"Arturo Prat 461, Oficina 1802","addressLocality":"Antofagasta","addressRegion":"AN","addressCountry":"CL"},
+        "telephone":"+56-55-2251-340"
+      },
+      {
+        "@type":"LocalBusiness",
+        "name":"Viña del Mar",
+        "address":{"@type":"PostalAddress","streetAddress":"Av. Nueva Libertad 1405, Oficina 1306","addressLocality":"Viña del Mar","addressRegion":"VS","addressCountry":"CL"},
+        "telephone":"+56-32-2690-759"
+      },
+      {
+        "@type":"LocalBusiness",
+        "name":"Puerto Montt",
+        "address":{"@type":"PostalAddress","streetAddress":"Benavente 550, Oficina 503","addressLocality":"Puerto Montt","addressRegion":"LL","addressCountry":"CL"},
+        "telephone":"+56-65-2348-910"
+      },
+      {
+        "@type":"LocalBusiness",
+        "name":"Copiapó",
+        "email":"clezcano@acfcapital.cl",
+        "address":{"@type":"PostalAddress","addressLocality":"Copiapó","addressRegion":"AT","addressCountry":"CL"}
+      },
+      {
+        "@type":"LocalBusiness",
+        "name":"Rancagua",
+        "email":"eguajardo@acfcapital.cl",
+        "address":{"@type":"PostalAddress","addressLocality":"Rancagua","addressRegion":"LI","addressCountry":"CL"},
+        "telephone":"+56-2-2338-9400"
+      }
+    ]
+  }
+  </script> <!-- JSON-LD: HowTo para el proceso -->
+   
+  <script type="application/ld+json" nonce="abc123">
 
-  <script src="app.js"></script>
+  {
+    "@context":"https://schema.org",
+    "@type":"HowTo",
+    "name":"Cómo funciona el factoring en ACF Capital",
+    "step":[
+      {"@type":"HowToStep","position":1,"name":"Envía tu documentación","text":"Sube tus facturas y documentos a través de la plataforma."},
+      {"@type":"HowToStep","position":2,"name":"Evaluamos tu solicitud","text":"Analizamos la documentación y respondemos en menos de 24h hábiles."},
+      {"@type":"HowToStep","position":3,"name":"Recibe tu dinero","text":"Transferimos los fondos a tu cuenta bancaria."}
+    ]
+  }
+  </script> 
+  <script src="./app.js" nonce="abc123" defer></script>
 </body>
 </html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,718 +1,86 @@
-/* Estilos generales */
 :root {
-  --blue: #283c67;
-  --gold: #e9b72d;
-  --light: #f5f6fa;
-  --dark: #222;
-  --font: 'Poppins', sans-serif;
+  --primary: #1e3a5f;
+  --accent: #f59e0b;
+  --success: #10b981;
+  --light: #f8fafc;
+  --lighter: #ffffff;
+  --text: #1f2937;
+  --text-light: #6b7280;
+  --border: #e5e7eb;
+  --shadow: rgba(0, 0, 0, 0.1);
+  --shadow-lg: rgba(0, 0, 0, 0.15);
+  --font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --border-radius: 12px;
+  --border-radius-sm: 8px;
+  --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body { font-family: var(--font); color: var(--text); background: var(--lighter); line-height: 1.6; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+.container { max-width: 1200px; margin: 0 auto; padding: 0 2rem; }
 
-body {
-  font-family: var(--font);
-  color: var(--dark);
-  background: #fff;
-  line-height: 1.6;
-  padding-top: 80px;
-}
+.skip-link{position:absolute;top:-40px;left:6px;background:var(--primary);color:#fff;padding:8px;text-decoration:none;border-radius:4px;z-index:1001}
+.skip-link:focus{top:6px}
 
-.container {
-  width: 100%;
-  max-width: none;
-  margin: 0;
-  padding: 0 1rem;
-}
+.header{background:var(--primary);color:var(--lighter);backdrop-filter:blur(10px);border-bottom:none;position:fixed;top:0;left:0;right:0;z-index:1000;transition:var(--transition)}
+.header.scrolled{box-shadow:0 4px 20px var(--shadow)}
+.header.hidden{transform:translateY(-100%)}
+.header-content{display:flex;align-items:center;justify-content:space-between;padding:1rem 0;min-height:80px}
+.logo{height:48px;width:auto}
+.nav-main{display:none;gap:2rem}
+.nav-main a{color:var(--lighter);text-decoration:none;font-weight:500;font-size:.95rem;padding:.5rem 0;position:relative;transition:var(--transition)}
+.nav-main a:hover{color:var(--accent)}
+.nav-main a::after{content:'';position:absolute;bottom:0;left:0;width:0;height:2px;background:var(--accent);transition:width .3s ease}
+.nav-main a:hover::after{width:100%}
+.nav-actions{display:flex;align-items:center;gap:1rem}
 
-/* Iconos */
-.icon {
-  color: var(--gold);
-  font-size: 2rem;
-  margin-bottom: 0.5rem;
-}
+.mobile-toggle{display:block;background:none;border:none;font-size:1.5rem;color:var(--lighter);cursor:pointer;padding:.5rem}
+.mobile-nav{display:none;position:absolute;top:100%;left:0;right:0;background:var(--lighter);border-top:1px solid var(--border);box-shadow:0 4px 20px var(--shadow);padding:1rem}
+.mobile-nav.open{display:block}
+.mobile-nav a{display:block;color:var(--text);text-decoration:none;padding:1rem 0;border-bottom:1px solid var(--border);font-weight:500}
+.mobile-nav a:hover{color:var(--primary)}
 
-/* Navbar */
-.navbar {
-  background-color: var(--blue);
-  color: var(--light);
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  z-index: 1000;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-.navbar.scrolled {
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-}
-.navbar.nav-hidden {
-  transform: translateY(-100%);
-}
-.navbar .container {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem 0;
-}
-.navbar nav {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 1.5rem;
-}
-.nav-actions {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-.navbar nav a {
-  text-decoration: none;
-  font-weight: 500;
-  color: var(--light);
-  cursor: pointer;
-  position: relative;
-}
-.navbar nav a::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: -4px;
-  width: 0;
-  height: 2px;
-  background: var(--gold);
-  transition: width 0.3s ease;
-}
-.navbar nav a:hover::after {
-  width: 100%;
-}
+@media (min-width: 768px){.mobile-toggle{display:none}.nav-main{display:flex}}
 
-.navbar nav button {
-  cursor: pointer;
-}
-.logo {
-  height: 72px;
-}
+.btn{display:inline-flex;align-items:center;justify-content:center;gap:.5rem;padding:.75rem 1.5rem;border-radius:var(--border-radius-sm);font-weight:600;font-size:.95rem;text-decoration:none;border:none;cursor:pointer;transition:var(--transition);white-space:nowrap}
+.btn-primary{background:var(--accent);color:var(--lighter);box-shadow:0 4px 12px rgba(245,158,11,.3)}
+.btn-primary:hover{background:#d97706;box-shadow:0 8px 25px rgba(245,158,11,.4);transform:translateY(-2px)}
+.btn-secondary{background:transparent;color:var(--primary);border:2px solid var(--primary)}
+.btn-secondary:hover{background:var(--primary);color:var(--lighter);transform:translateY(-2px)}
+.header .btn-secondary{color:var(--lighter);border-color:var(--lighter)}
+.header .btn-secondary:hover{background:var(--lighter);color:var(--primary)}
+.btn-ghost{background:transparent;color:var(--lighter);border:2px solid rgba(255,255,255,.3)}
+.btn-ghost:hover{background:rgba(255,255,255,.1);border-color:var(--lighter)}
 
-@media (max-width: 768px) {
-  .navbar .container {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-  .navbar nav {
-    flex-direction: column;
-    align-items: flex-start;
-    width: 100%;
-  }
-  .navbar nav a,
-  .nav-actions button {
-    margin: 0.5rem 0 0;
-  }
-  .nav-actions {
-    width: 100%;
-    flex-direction: column;
-    align-items: flex-start;
-  }
+.hero{background:linear-gradient(135deg,var(--primary) 0%,#0f172a 100%);color:var(--lighter);padding:8rem 0 6rem;margin-top:80px;position:relative;overflow:hidden}
+.hero-content{display:grid;gap:3rem;align-items:center;position:relative;z-index:1}
+.hero-text{text-align:center}
+.hero h1{font-size:clamp(2.5rem,5vw,3.5rem);font-weight:700;margin-bottom:1.5rem;line-height:1.2}
+.hero-subtitle{font-size:1.25rem;color:rgba(255,255,255,.9);margin-bottom:2rem;max-width:600px;margin-left:auto;margin-right:auto}
+.hero-cta{display:flex;flex-direction:column;gap:1rem;align-items:center}
+.hero-image{position:relative;height:400px;border-radius:var(--border-radius);overflow:hidden;box-shadow:0 20px 50px rgba(0,0,0,.3)}
+.gallery img{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;opacity:0;transition:opacity 1s ease-in-out}
+.gallery img.active{opacity:1}
 
-}
+@media (min-width: 768px){.hero-content{grid-template-columns:1fr 1fr}.hero-text{text-align:left}.hero-cta{flex-direction:row;justify-content:flex-start}}
 
-/* Hero */
-/* Hero */
-.hero {
-  background: linear-gradient(135deg, var(--blue), #1b2b4d);
+.stats{padding:4rem 0;background:var(--light)}
+.stats h2{text-align:center;font-size:2.5rem;font-weight:700;margin-bottom:3rem;color:var(--primary)}
+.stats-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:2rem}
+.stat-card{background:var(--lighter);padding:2rem;border-radius:var(--border-radius);text-align:center;box-shadow:0 4px 20px var(--shadow);transition:var(--transition);border:1px solid var(--border)}
+.stat-card:hover{transform:translateY(-4px);box-shadow:0 8px 30px var(--shadow-lg)}
+.stat-value{font-size:3rem;font-weight:700;color:var(--primary);margin-bottom:.5rem;background:linear-gradient(135deg,var(--primary),var(--accent));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+.stat-label{color:var(--text-light);font-weight:500}
 
-  color: #fff;
-  padding: 6rem 0;
-}
-.hero-grid {
-  display: grid;
-  gap: 2rem;
-  align-items: center;
-}
- .hero-text {
-   text-align: center;
- }
-@media (min-width: 768px) {
-  .hero-grid {
-    grid-template-columns: 1fr 1fr;
-  }
-  .hero-text {
-    text-align: left;
-  }
-}
-.hero h1 {
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
-}
-.hero p {
-  margin-bottom: 2rem;
-}
-.hero-image img {
-  width: 100%;
-  height: auto;
-  border-radius: 8px;
-}
+.services{padding:6rem 0;background:var(--lighter)}
+.services h2{text-align:center;font-size:2.5rem;font-weight:700;margin-bottom:1rem;color:var(--primary)}
+.services-subtitle{text-align:center;font-size:1.125rem;color:var(--text-light);margin-bottom:3rem;max-width:600px;margin-left:auto;margin-right:auto}
+.services-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:2rem}
+.service-card{background:var(--lighter);padding:2.5rem;border-radius:var(--border-radius);text-align:center;box-shadow:0 4px 20px var(--shadow);transition:var(--transition);border:1px solid var(--border);position:relative;overflow:hidden}
+.service-card::before{content:'';position:absolute;top:0;left:0;width:100%;height:4px;background:linear-gradient(90deg,var(--accent),var(--primary))}
+.service-card:hover{transform:translateY(-8px);box-shadow:0 12px 40px var(--shadow-lg)}
+.service-icon{width:80px;height:80px;background:linear-gradient(135deg,var(--accent),#fbbf24);color:var(--lighter);border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:2rem;margin:0 auto 1.5rem;box-shadow:0 8px 25px rgba(245,158,11,.3)}
+.service-card h3{font-size:1.5rem;font-weight:600;margin-bottom:1rem;color:var(--primary)}
+.service-card p{color:var(--text-light);line-height:1.7}
 
-/* Gallery */
-.gallery {
-  position: relative;
-  height: 300px;
-  overflow: hidden;
-  border-radius: 8px;
-}
-
-.gallery img {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  opacity: 0;
-  transition: opacity 1s ease-in-out;
-}
-
-.gallery img.active {
-  opacity: 1;
-}
-
-/* Buttons */
-button {
-  background: var(--gold);
-  color: var(--blue);
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  font-weight: 600;
-  cursor: pointer;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  transition: background-color 0.3s ease, box-shadow 0.3s ease;
-}
-
-button:hover {
-  background: #d1a121;
-  box-shadow: 0 4px 6px rgba(0,0,0,0.15);
-}
-
-.btn-primary {
-  background: var(--gold);
-  color: var(--dark);
-  padding: 0.75rem 1.5rem;
-  border-radius: 4px;
-  text-decoration: none;
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  transition: background-color 0.3s ease, box-shadow 0.3s ease;
-}
-.btn-primary:hover {
-  background: #d1a121;
-  box-shadow: 0 4px 6px rgba(0,0,0,0.15);
-}
-
-
-.btn-accent {
-  background: var(--gold);
-  color: var(--blue);
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  justify-content: center;
-  max-width: 100%;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  transition: background-color 0.3s ease, box-shadow 0.3s ease;
-}
-
-.btn-secondary {
-  background: transparent;
-  color: var(--light);
-  border: 1px solid var(--light);
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  justify-content: center;
-  max-width: 100%;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  transition: background-color 0.3s ease, box-shadow 0.3s ease;
-}
-
-.btn-nav {
-  width: auto;
-  max-width: 180px;
-  white-space: nowrap;
-}
-
-.btn-secondary:hover {
-  background: var(--blue);
-  color: #fff;
-  box-shadow: 0 4px 6px rgba(0,0,0,0.15);
-}
-
-.btn-accent:hover {
-  background: #d1a121;
-  box-shadow: 0 4px 6px rgba(0,0,0,0.15);
-}
-
-/* Navbar button overrides */
-.navbar .btn-secondary.btn-nav {
-  color: #fff;
-  border-color: #fff;
-}
-.navbar .btn-secondary.btn-nav:hover {
-  background: #fff;
-  color: var(--blue);
-}
-.navbar .btn-accent.btn-nav {
-  color: #fff;
-}
-
-/* Services */
-.services {
-  padding: 3rem 0;
-  background: #fff;
-}
-.services h2 {
-  text-align: center;
-  margin-bottom: 2rem;
-}
-.cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1.5rem;
-}
-.card {
-  background: #fff;
-  padding: 1.5rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-  text-align: center;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-
-}
-.card h3 {
-  margin-bottom: 0.5rem;
-}
-.card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-}
-.card .icon {
-  background: var(--light);
-  color: var(--blue);
-  width: 60px;
-  height: 60px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.5rem;
-  margin: 0 auto 1rem;
-}
-
-/* Stats */
-.stats {
-  padding: 3rem 0;
-  background: var(--light);
-}
-
-.stats h2 {
-  text-align: center;
-  margin-bottom: 2rem;
-}
-
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.5rem;
-  text-align: center;
-}
-
-.stats-card {
-  background: #fff;
-  padding: 1.5rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-}
-
-.stat-value {
-  font-size: 2rem;
-  font-weight: 700;
-  color: var(--blue);
-}
-
-.stat-label {
-  margin-top: 0.5rem;
-  font-size: 0.9rem;
-}
-
-
-/* How it works */
-.how-it-works {
-  padding: 3rem 0;
-  background: var(--light);
-}
-.how-it-works h2 {
-  text-align: center;
-  margin-bottom: 2rem;
-}
-.how-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1.5rem;
-}
-.how-grid div {
-  background: #fff;
-  padding: 1.5rem;
-  border-radius: 8px;
-  text-align: center;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-}
-
-.how-grid i {
-  background: var(--light);
-  color: var(--blue);
-  width: 60px;
-  height: 60px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.5rem;
-  margin: 0 auto 1rem;
-}
-
-
-/* Simulator */
-.calculator {
-  padding: 3rem 0;
-}
-.calculator .tagline {
-  text-align: center;
-  color: var(--blue);
-  font-weight: 600;
-}
-.calculator h2 {
-  text-align: center;
-  margin: 0.5rem 0 2rem;
-}
-.calc-wrapper {
-  background: #fff;
-  padding: 2rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-  display: grid;
-  gap: 2rem;
-}
-@media (min-width: 800px) {
-  .calc-wrapper {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-.calc-form {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-.amount-input {
-  display: flex;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-}
-.amount-input .currency {
-  background: var(--light);
-  padding: 0.5rem;
-  border-right: 1px solid #ccc;
-  font-weight: 600;
-}
-.amount-input input {
-  flex: 1;
-  border: none;
-  padding: 0.5rem;
-}
-.preset-amounts, .term-buttons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-.preset-amounts button,
-.term-buttons button {
-  padding: 0.4rem 0.8rem;
-  border: 1px solid var(--blue);
-  background: transparent;
-  color: var(--blue);
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.85rem;
-}
-.term-buttons button.active {
-  background: var(--blue);
-  color: #fff;
-}
-#rate {
-  width: 100%;
-}
-.calc-summary {
-  background: var(--light);
-  padding: 1.5rem;
-  border-radius: 8px;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-.calc-summary p {
-  display: flex;
-  justify-content: space-between;
-}
-.calc-summary .result {
-  color: green;
-  font-weight: 700;
-  margin-top: 0.5rem;
-}
-
-.hidden { display: none; }
-
-/* Login modal */
-.modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0,0,0,0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 2000;
-}
-
-.modal.hidden {
-  display: none;
-}
-.modal-content {
-  background: #fff;
-  padding: 2rem;
-  border-radius: 8px;
-  width: 400px;
-  max-width: 90%;
-  position: relative;
-  color: var(--dark);
-}
-.modal-close {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  cursor: pointer;
-  color: var(--dark);
-  padding: 0;
-  box-shadow: none;
-}
-.login-form {
-  display: grid;
-  gap: 0.75rem;
-}
-.login-form label {
-  text-align: left;
-  font-weight: 500;
-
-}
-.login-form input {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-}
-.btn-login {
-
-  background: var(--gold);
-  color: var(--blue);
-  border: none;
-  padding: 0.5rem;
-  border-radius: 4px;
-  cursor: pointer;
-  font-weight: 600;
-
-}
-.forgot-link {
-  display: block;
-  margin-top: 0.5rem;
-  font-size: 0.9rem;
-
-  color: var(--blue);
-  text-decoration: underline;
-}
-
-/* Contact */
-.contact {
-  padding: 3rem 0;
-  background: #fff;
-  text-align: center;
-}
-.contact .container {
-  max-width: 600px;
-  margin: 0 auto;
-}
-.contact .address {
-  text-align: center;
-  margin-bottom: 1rem;
-}
-.contact-form {
-  display: grid;
-  gap: 1rem;
-  max-width: 500px;
-  margin: 0 auto;
-  text-align: left;
-}
-.contact-form label {
-  display: flex;
-  flex-direction: column;
-  font-size: 0.9rem;
-}
-.contact-form input,
-.contact-form textarea {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-}
-
-/* Offices */
-.offices {
-  padding: 3rem 0;
-  background: var(--light);
-}
-.offices h2 {
-  text-align: center;
-  margin-bottom: 2rem;
-}
-.offices-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 2rem;
-}
-.offices-grid div p {
-  margin-bottom: 1rem;
-}
-.offices-grid div p strong {
-  color: var(--blue);
-}
-
-/* WhatsApp button */
-.whatsapp-btn {
-  position: fixed;
-  bottom: 20px;
-  right: 20px;
-  background: #25D366;
-  color: #fff;
-  width: 70px;
-  height: 70px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 2.5rem;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
-  z-index: 100;
-}
-.whatsapp-btn:hover {
-  background: #1ebe5d;
-}
-
-/* Footer */
-.site-footer {
-  background: var(--blue);
-  color: #fff;
-  margin-top: 2rem;
-  font-size: 0.9rem;
-}
-.site-footer a {
-  color: #fff;
-  text-decoration: none;
-}
-.site-footer a:hover {
-  color: var(--gold);
-}
-.footer-top {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2rem;
-  padding: 3rem 0;
-}
-.footer-brand {
-  flex: 1 1 200px;
-}
-.footer-logo {
-  height: 40px;
-  margin-bottom: 0.5rem;
-}
-.footer-links {
-  flex: 3 1 400px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2rem;
-}
-.footer-column {
-  min-width: 160px;
-}
-.footer-column h4 {
-  margin-bottom: 0.5rem;
-  font-size: 1rem;
-  color: var(--gold);
-}
-.footer-column ul {
-  list-style: none;
-  padding: 0;
-}
-.footer-column li {
-  margin: 0.3rem 0;
-}
-.footer-bottom {
-  border-top: 1px solid rgba(255,255,255,0.1);
-  padding: 1rem 0;
-  font-size: 0.8rem;
-}
-.footer-bottom .container {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  align-items: center;
-  text-align: center;
-}
-.footer-legal {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  justify-content: center;
-}
-@media (min-width: 768px) {
-  .footer-bottom .container {
-    flex-direction: row;
-    justify-content: space-between;
-    text-align: left;
-  }
-}
-
-/* Reveal animations */
-.reveal {
-  opacity: 0;
-  transform: translateY(40px);
-  transition: opacity 0.8s ease, transform 0.8s ease;
-}
-
-.reveal.visible {
-  opacity: 1;
-  transform: none;
-}


### PR DESCRIPTION
## Summary
- brand header with ACF blue background and white text
- restore Font Awesome icons in navigation, hero, services, and process sections for clearer structure
- load official ACF logo from upstream SVG across docs and public assets

## Testing
- `npm test`
- `tidy -qe docs/index.html` (warnings: trimming empty <i>, proprietary attributes)


------
https://chatgpt.com/codex/tasks/task_e_68b1d5402480832f8f5e3052249ca0ee